### PR TITLE
Patch to allow Confetti with Proxy RoutePrefix

### DIFF
--- a/src/module.json
+++ b/src/module.json
@@ -12,6 +12,7 @@
 		}
 	],
 	"esmodules": [
+		"greensock/esm/all.js",
 		"foundryvtt-confetti.js"
 	],
 	"styles": [

--- a/src/module/classes/Confetti.ts
+++ b/src/module/classes/Confetti.ts
@@ -1,7 +1,7 @@
 import { ConfettiStrength, MODULE_ID, MySettings, SOUNDS } from '../constants';
 import { log, random } from '../helpers';
 //@ts-ignore
-import { gsap, TweenLite, Power4, Physics2DPlugin } from '/scripts/greensock/esm/all.js';
+import { gsap, TweenLite, Power4, Physics2DPlugin } from '../../../../scripts/greensock/esm/all.js';
 //@ts-ignore
 gsap.registerPlugin(Physics2DPlugin);
 


### PR DESCRIPTION
Slight update to reference for greensock and path to import from to work with a routePrefix Foundry setup